### PR TITLE
Support Android logging

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools",
+        "twxs.cmake"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "sonarlint.pathToCompileCommands": "${workspaceFolder}/build/compile_commands.json"
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.12)
 project(logger C)
 
 set(CMAKE_C_FLAGS "-Wall -std=c89")
@@ -18,6 +18,12 @@ set(source_files
 add_library(${PROJECT_NAME} SHARED ${source_files})
 add_library(${PROJECT_NAME}_static STATIC ${source_files})
 set_target_properties(${PROJECT_NAME}_static PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
+
+# Android NDK log library
+if(ANDROID)
+    target_link_libraries(${PROJECT_NAME}        PRIVATE log)
+    target_link_libraries(${PROJECT_NAME}_static INTERFACE log)
+endif()
 
 # Export the include directory
 target_include_directories(

--- a/CUSTOMIZATIONS.md
+++ b/CUSTOMIZATIONS.md
@@ -1,0 +1,41 @@
+# Customizations
+
+## CMake
+
+The `cmake_minimum_required` was raised from 2.8.11 to 2.8.12
+to avoid the "Compatibility with CMake < 2.8.12 will be removed from a future version of
+CMake." deprecation warning.
+
+And unsure about the mechanism, but there is also a nice side-benefit that Visual Studio Code
+won't complain about `extern "C" {` in the C headers.
+
+## Visual Studio Code
+
+Various files in `.vscode/` have been committed to support easy Visual Studio Code development.
+
+## Android
+
+### Android Development
+
+To develop with Android, download and unpack the Android NDK. For this example I am using
+Android NDK 23.1.7779620.
+
+1. Run `CMake: Edit User-Local CMake Kits`.
+2. Add an entry like:
+
+   ```json
+   {
+        "name": "Android NDK 23.1.7779620",
+        "compilers": {
+            "C": "/some/path/android-sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android31-clang",
+            "CXX": "/some/path/android-sdk/ndk/23.1.7779620/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android31-clang++"
+        },
+        "isTrusted": true
+   }
+   ```
+3. Run `CMake: Select a Kit` and choose your Android NDK.
+4. Run `CMake: Configure`.
+5. Run `CMake: Build`. The build may show an error that can be ignored:
+   > `[proc] The command: x86_64-linux-android31-clang -v failed with error: Error: spawn x86_64-linux-android31-clang ENOENT`
+
+The last three (3) commands you could do from the UI (both the toolbar and the CMake Panel).

--- a/src/logger.h
+++ b/src/logger.h
@@ -51,6 +51,24 @@ int logger_initConsoleLogger(FILE* output);
 int logger_initFileLogger(const char* filename, long maxFileSize, unsigned char maxBackupFiles);
 
 /**
+ * Initialize the logger as an Android logger viewable in Logcat.
+ *
+ * The tag usually identifies the class or activity where the log
+ * call occurs, like "MyActivity". If the tag is NULL, the Android
+ * default tag (the value of getprogname()) will be used. The default
+ * tag truncated to the maximum log message size, though appropriate
+ * tags should be much smaller.
+ *
+ * Support for Android requires that the project was built using
+ * the Android NDK toolchain. An error (0) will be returned if
+ * Android is not supported.
+ *
+ * @param[in] tag The source of a log message.
+ * @return Non-zero value upon success or 0 on error
+ */
+int logger_initAndroid(const char* tag);
+
+/**
  * Set the log level.
  * Message levels lower than this value will be discarded.
  * The default log level is INFO.
@@ -92,6 +110,7 @@ void logger_flush(void);
  * Make sure to call one of the following initialize functions before starting logging.
  * - logger_initConsoleLogger()
  * - logger_initFileLogger()
+ * - logger_initAndroid()
  *
  * @param[in] level A log level
  * @param[in] file A file name string


### PR DESCRIPTION
This enables the use of Android NDK logging: https://developer.android.com/ndk/reference/group/logging

It also bumps up CMake minimum from 2.8.11 to 2.8.12 to avoid the CMake deprecation warning.